### PR TITLE
Avoid circular import issues.

### DIFF
--- a/flag/models.py
+++ b/flag/models.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from enum import IntEnum, unique
 
-from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
@@ -12,7 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from flag.managers import FlagInstanceManager, FlagManager
 from flag.conf import settings
 
-User = get_user_model()
+User = settings.AUTH_USER_MODEL
 
 
 class Flag(models.Model):

--- a/flag/utils.py
+++ b/flag/utils.py
@@ -1,12 +1,9 @@
 """General purpose functions that provide utility throughout the application"""
+from django.contrib.auth import get_user_model
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
-
-
-User = get_user_model()
 
 
 def get_content_type(model_obj):
@@ -31,6 +28,7 @@ def get_model_object(*, app_name, model_name, model_id):
 
 
 def get_user_for_model(obj):
+    User = get_user_model()
     for field in obj._meta.fields:
         if field.related_model == User:
             return getattr(obj, field.name)


### PR DESCRIPTION
Django documentation recommends using settings.AUTH_USER_MODEL over get_user_model() when you define a foreign key or many-to-many relation to the user model.

https://docs.djangoproject.com/en/3.1/topics/auth/customizing/

helped fix a circular import issue in my project.

- fixes #19 