### PR TITLE
feat: Add support for django 40 and 41

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,6 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,12 @@ classifiers =
     Framework :: Django :: 3.0
     Framework :: Django :: 3.1
     Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -35,7 +36,7 @@ keywords = django flag report moderate
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires = django
 zip_safe = False
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py37-dj{21, 22, 30, 31, 32}
     py38-dj{21, 22, 30, 31, 32, 40}
     py39-dj{21, 22, 30, 31, 32, 40}
-    py310-dj{40}
+    py310-dj{40, 41, main}
     lint, docs
 
 [gh-actions]
@@ -35,6 +35,8 @@ deps =
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
+    dj40: Django>=4.0,<4.1
+    dj41: Django>=4.1,<4.2
     djmain: https://github.com/django/django/archive/main.tar.gz
 
 usedevelop = True
@@ -43,3 +45,12 @@ commands =
     python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run --parallel-mode -m pytest {posargs}
 setenv =
     PYTHONDONTWRITEBYTECODE=1
+
+[testenv:py38-djmain]
+ignore_outcome = true
+
+[testenv:py39-djmain]
+ignore_outcome = true
+
+[testenv:py310-djmain]
+ignore_outcome = true


### PR DESCRIPTION
- also drop the same for python 3.6
  - since python 3.6 had long reached its end of life
    we can safely assume, most people will remain unaffected.

- the support for django 40 was added to tox earlier but
  not for all python versions, fix that part as well.

- also, start running tests for main branch of django as well.